### PR TITLE
Prevent memory exhaustion in live monitor by purging oldest items

### DIFF
--- a/SupMain.cs
+++ b/SupMain.cs
@@ -3711,6 +3711,7 @@ namespace SUP
                             this.Invoke((MethodInvoker)delegate
                             {
                                 AddToSearchResults(foundobjects);
+                                RemoveOverFlowMessages(supFlow);
                             });
 
                         }

--- a/patch.diff
+++ b/patch.diff
@@ -1,52 +1,57 @@
-<<<<<<< SEARCH
-        private static bool IsSvgExtension(string extension) =>
-            string.Equals(extension, ".svg", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(extension, ".svgz", StringComparison.OrdinalIgnoreCase);
-
-
-        public ObjectBrowser(string searchaddress = "", bool isTestnet = true)
-=======
-        private static bool IsSvgExtension(string extension) =>
-            string.Equals(extension, ".svg", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(extension, ".svgz", StringComparison.OrdinalIgnoreCase);
-
-        private bool IsUnsupportedImageFormat(string filePath)
-        {
-            try
-            {
-                if (!System.IO.File.Exists(filePath)) return false;
-
-                using (System.IO.FileStream fs = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
-                {
-                    if (fs.Length < 12) return false;
-
-                    byte[] header = new byte[12];
-                    fs.Read(header, 0, 12);
-
-                    // Check for RIFF WEBP
-                    if (header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 && // RIFF
-                        header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)   // WEBP
-                    {
-                        return true;
-                    }
-
-                    // Check for ftypavif (AVIF) and other HEIF/HEIC formats
-                    if (header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70) // ftyp
-                    {
-                        if (header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66) return true; // avif
-                        if (header[8] == 0x6d && header[9] == 0x69 && header[10] == 0x66 && header[11] == 0x31) return true; // mif1
-                        if (header[8] == 0x6d && header[9] == 0x73 && header[10] == 0x66 && header[11] == 0x31) return true; // msf1
-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x69 && header[11] == 0x63) return true; // heic
-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x69 && header[11] == 0x78) return true; // heix
-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x76 && header[11] == 0x63) return true; // hevc
-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x76 && header[11] == 0x78) return true; // hevx
-                    }
-                }
-            }
-            catch { }
-
-            return false;
-        }
-
-        public ObjectBrowser(string searchaddress = "", bool isTestnet = true)
->>>>>>> REPLACE
+diff --git a/patch.diff b/patch.diff
+index cd631b1..e69de29 100644
+--- a/patch.diff
++++ b/patch.diff
+@@ -1,52 +0,0 @@
+-<<<<<<< SEARCH
+-        private static bool IsSvgExtension(string extension) =>
+-            string.Equals(extension, ".svg", StringComparison.OrdinalIgnoreCase) ||
+-            string.Equals(extension, ".svgz", StringComparison.OrdinalIgnoreCase);
+-
+-
+-        public ObjectBrowser(string searchaddress = "", bool isTestnet = true)
+-=======
+-        private static bool IsSvgExtension(string extension) =>
+-            string.Equals(extension, ".svg", StringComparison.OrdinalIgnoreCase) ||
+-            string.Equals(extension, ".svgz", StringComparison.OrdinalIgnoreCase);
+-
+-        private bool IsUnsupportedImageFormat(string filePath)
+-        {
+-            try
+-            {
+-                if (!System.IO.File.Exists(filePath)) return false;
+-
+-                using (System.IO.FileStream fs = new System.IO.FileStream(filePath, System.IO.FileMode.Open, System.IO.FileAccess.Read))
+-                {
+-                    if (fs.Length < 12) return false;
+-
+-                    byte[] header = new byte[12];
+-                    fs.Read(header, 0, 12);
+-
+-                    // Check for RIFF WEBP
+-                    if (header[0] == 0x52 && header[1] == 0x49 && header[2] == 0x46 && header[3] == 0x46 && // RIFF
+-                        header[8] == 0x57 && header[9] == 0x45 && header[10] == 0x42 && header[11] == 0x50)   // WEBP
+-                    {
+-                        return true;
+-                    }
+-
+-                    // Check for ftypavif (AVIF) and other HEIF/HEIC formats
+-                    if (header[4] == 0x66 && header[5] == 0x74 && header[6] == 0x79 && header[7] == 0x70) // ftyp
+-                    {
+-                        if (header[8] == 0x61 && header[9] == 0x76 && header[10] == 0x69 && header[11] == 0x66) return true; // avif
+-                        if (header[8] == 0x6d && header[9] == 0x69 && header[10] == 0x66 && header[11] == 0x31) return true; // mif1
+-                        if (header[8] == 0x6d && header[9] == 0x73 && header[10] == 0x66 && header[11] == 0x31) return true; // msf1
+-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x69 && header[11] == 0x63) return true; // heic
+-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x69 && header[11] == 0x78) return true; // heix
+-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x76 && header[11] == 0x63) return true; // hevc
+-                        if (header[8] == 0x68 && header[9] == 0x65 && header[10] == 0x76 && header[11] == 0x78) return true; // hevx
+-                    }
+-                }
+-            }
+-            catch { }
+-
+-            return false;
+-        }
+-
+-        public ObjectBrowser(string searchaddress = "", bool isTestnet = true)
+->>>>>>> REPLACE


### PR DESCRIPTION
The user reported that the live monitor would eventually stop functioning after ~12 hours of running due to running out of memory. This happens because the live monitor thread continually appends results to `supFlow` without removing any of the old results, growing indefinitely.

The fix introduces a call to the existing `RemoveOverFlowMessages(supFlow)` helper function within the `Invoke` delegate of `tmrSearchMemoryPool_Tick` directly following the addition of new items (`AddToSearchResults(foundobjects)`). `RemoveOverFlowMessages` is already designed to limit the size of `supFlow` (to a max of ~200 controls) safely.

---
*PR created automatically by Jules for task [14375714325882110120](https://jules.google.com/task/14375714325882110120) started by @embiimob*