### PR TITLE
Fix GetProfileByURN early return breaking URN transfers

### DIFF
--- a/P2FK/contracts/PRO.cs
+++ b/P2FK/contracts/PRO.cs
@@ -320,11 +320,13 @@ namespace SUP.P2FK
 
 
             HashSet<string> addedValues = new HashSet<string>();
+            bool calculated = false;
 
             foreach (Root transaction in profileTransactions)
             {
                 if (transaction.Id > intProcessHeight)
                 {
+                    calculated = true;
                     intProcessHeight = transaction.Id;
                     //ignore any transaction that is not signed
                     if (transaction.Signed && transaction.File.ContainsKey("PRO") && ((profileState.Creators != null && profileState.Creators.Contains(transaction.SignedBy)) || profileState.Creators == null))
@@ -341,44 +343,10 @@ namespace SUP.P2FK
                             {
                                 if (isObject.Creators.Contains(findObject))
                                 {
-
                                     isObject.Id = profileTransactions.Max(max => max.Id);
                                     isObject.ProcessHeight = intProcessHeight;
-
-                                    var profileSerialized = JsonConvert.SerializeObject(isObject);
-                                    if (Root.WasLastFetchComplete(profileaddress))
-                                    {
-                                        bool canCommit = true;
-                                        try
-                                        {
-                                            JSONOBJ = System.IO.File.ReadAllText(profileUrnPath);
-                                            PROState existing = JsonConvert.DeserializeObject<PROState>(JSONOBJ);
-                                            if (existing != null)
-                                            {
-                                                if (existing.Id > isObject.Id) { canCommit = false; }
-                                                else if (existing.Id == isObject.Id)
-                                                {
-                                                    // At equal cursor, keep the richer creator map.
-                                                    int existingCreators = existing.Creators == null ? 0 : existing.Creators.Count;
-                                                    int newCreators = isObject.Creators == null ? 0 : isObject.Creators.Count;
-                                                    if (existingCreators > newCreators) { canCommit = false; }
-                                                }
-                                            }
-                                        }
-                                        catch { };
-
-                                        if (canCommit)
-                                        {
-                                            Root.AtomicWriteCacheFile(profileUrnPath, profileSerialized);
-                                        }
-                                    }
-
-
-                                    return isObject;
-
+                                    profileState = isObject;
                                 }
-
-
                             }
 
                         }
@@ -386,6 +354,36 @@ namespace SUP.P2FK
                 }
 
             }
+
+            if (calculated && Root.WasLastFetchComplete(profileaddress) && profileState.URN != null)
+            {
+
+                bool canCommit = true;
+                try
+                {
+                    JSONOBJ = System.IO.File.ReadAllText(profileUrnPath);
+                    PROState existing = JsonConvert.DeserializeObject<PROState>(JSONOBJ);
+                    if (existing != null)
+                    {
+                        if (existing.Id > profileState.Id) { canCommit = false; }
+                        else if (existing.Id == profileState.Id)
+                        {
+                            // At equal cursor, keep the richer creator map.
+                            int existingCreators = existing.Creators == null ? 0 : existing.Creators.Count;
+                            int newCreators = profileState.Creators == null ? 0 : profileState.Creators.Count;
+                            if (existingCreators > newCreators) { canCommit = false; }
+                        }
+                    }
+                }
+                catch { };
+
+                if (canCommit)
+                {
+                    var profileSerialized = JsonConvert.SerializeObject(profileState);
+                    Root.AtomicWriteCacheFile(profileUrnPath, profileSerialized);
+                }
+            }
+
 
                 return profileState;
             }


### PR DESCRIPTION
This commit fixes a bug in `PROState.GetProfileByURN` where the function would incorrectly catch on an older, obsolete claim and fail to honor a transfer to a new creator address.

The old logic immediately returned upon discovering the first transaction that successfully resolved the URN via `GetProfileByAddress(findObject)`. By changing the loop to iteratively update `profileState` and removing the early return, the logic appropriately steps through the entire transaction chain for the URN. As transfers occur (original creator adds new address, new address assumes control), the `Contains(transaction.SignedBy)` logic organically works across the loop since `profileState` reflects the new valid creator context.
The caching update (`Root.AtomicWriteCacheFile`) was subsequently shifted outside the loop to execute only once with the final, fully-resolved state.

---
*PR created automatically by Jules for task [15807905596006082608](https://jules.google.com/task/15807905596006082608) started by @embiimob*